### PR TITLE
Resolves console issue 'PHP Warning: var_export does not handle circular references'

### DIFF
--- a/src/MustacheEngine.php
+++ b/src/MustacheEngine.php
@@ -4,6 +4,7 @@ namespace Laratash;
 use Illuminate\View\Engines\EngineInterface;
 use Illuminate\Filesystem\Filesystem;
 use Mustache_Engine;
+use App;
 
 class MustacheEngine implements EngineInterface
 {
@@ -20,7 +21,9 @@ class MustacheEngine implements EngineInterface
         $view = $this->files->get($path);
         $app = app();
 
-        $m = new Mustache_Engine($app['config']->get('laratash'));
+        $config = $app['config']->get('laratash');
+        $config['partials_loader'] = App::make($config['partials_loader']);
+        $m = new Mustache_Engine($config);
  
         if (isset($data['__context']) && is_object($data['__context'])) {
             $data = $data['__context'];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -12,9 +12,9 @@ return array(
     // It is strongly recommended that you configure your umask properly rather than overriding permissions here.
     // 'cache_file_mode' => 0666,
 
-    // A Mustache loader instance for partials. If none is specified, defaults to an ArrayLoader for the supplied
+    // A Mustache loader class for partials. If none is specified, defaults to an ArrayLoader for the supplied
     // partials option, if present, and falls back to the specified template loader.
-    'partials_loader' => App::make('Laratash\FilesystemLoader'),
+    'partials_loader' => 'Laratash\FilesystemLoader',
     
     // An array of Mustache partials. Useful for quick-and-dirty string template loading,
     // but not as efficient or lazy as a Filesystem (or database) loader.


### PR DESCRIPTION
This only occurs when running `php artisan config:cache` in Laravel 5.1 config:cache uses var_export to generate a configuration cache file and it doesn't like exporting objects or rather the references inside the FilesystemLoader instance.
