### PR TITLE
Remove attempt at `->toArray()` on passed object

### DIFF
--- a/src/FilesystemLoader.php
+++ b/src/FilesystemLoader.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Laratash;
 
 use Illuminate\Filesystem\Filesystem;
@@ -15,8 +16,8 @@ class FilesystemLoader implements Mustache_loader
 
     public function __construct(Filesystem $files)
     {
-        $this->app    = app();
-        $this->files  = $files;
+        $this->app = app();
+        $this->files = $files;
         $this->finder = $this->app['view']->getFinder();
     }
 
@@ -25,12 +26,14 @@ class FilesystemLoader implements Mustache_loader
         if (!isset($this->templates[$name])) {
             $this->templates[$name] = $this->loadFile($name);
         }
+
         return $this->templates[$name];
     }
 
     public function loadFile($name)
     {
         $path = $this->finder->find($name);
+
         return $this->files->get($path);
     }
 }

--- a/src/LaratashServiceProvider.php
+++ b/src/LaratashServiceProvider.php
@@ -1,7 +1,8 @@
-<?php namespace Laratash;
+<?php
+
+namespace Laratash;
 
 use Illuminate\Support\ServiceProvider;
-use Illuminate\View\ViewFinderInterface;
 
 class LaratashServiceProvider extends ServiceProvider
 {
@@ -38,13 +39,13 @@ class LaratashServiceProvider extends ServiceProvider
 
     private function setupConfig()
     {
-        $config = __DIR__ . '/config/config.php';
+        $config = __DIR__.'/config/config.php';
         $this->mergeConfigFrom($config, 'laratash');
     }
 
     private function registerMustacheEngine()
     {
-        $this->app->bind('mustache.engine', function() {
+        $this->app->bind('mustache.engine', function () {
             return $this->app->make('Laratash\MustacheEngine');
         });
     }

--- a/src/MustacheEngine.php
+++ b/src/MustacheEngine.php
@@ -1,10 +1,10 @@
 <?php
+
 namespace Laratash;
 
-use Illuminate\View\Engines\EngineInterface;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Engines\EngineInterface;
 use Mustache_Engine;
-use App;
 
 class MustacheEngine implements EngineInterface
 {
@@ -19,20 +19,19 @@ class MustacheEngine implements EngineInterface
     public function get($path, array $data = array())
     {
         $view = $this->files->get($path);
+
         $app = app();
 
-        $config = $app['config']->get('laratash');
-        $config['partials_loader'] = App::make($config['partials_loader']);
+        $config = config('laratash');
+
+        $config['partials_loader'] = $app->make($config['partials_loader']);
+
         $m = new Mustache_Engine($config);
- 
+
         if (isset($data['__context']) && is_object($data['__context'])) {
             $data = $data['__context'];
-        } else {
-            $data = array_map(function ($item) {
-                return (is_object($item) && method_exists($item, 'toArray')) ? $item->toArray() : $item;
-            }, $data);
         }
- 
+
         return $m->render($view, $data);
     }
 }


### PR DESCRIPTION
Tried to be too clever in the past by calling `->toArray()` on objects passed in the view data if the method existed.

it never really worked well (not being a deep traversal) and added a tiny bit of unnecessary magic, which was confusing as hell if stepping back into a project that used this package.