### PR TITLE
Add compatibilty with Laravel 5.5 "EngineInterface -> Engine as Engin…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "illuminate/view": "~5.0",
-        "illuminate/filesystem": "~5.0",
-        "illuminate/support": "~5.0",
+        "php": ">=7.0.0",
+        "illuminate/view": "~5.5",
+        "illuminate/filesystem": "~5.5",
+        "illuminate/support": "~5.5",
         "mustache/mustache": "~2.7"
     },
     "autoload": {

--- a/src/MustacheEngine.php
+++ b/src/MustacheEngine.php
@@ -3,7 +3,7 @@
 namespace Laratash;
 
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\View\Engines\EngineInterface;
+use Illuminate\Contracts\View\Engine as EngineInterface;
 use Mustache_Engine;
 
 class MustacheEngine implements EngineInterface


### PR DESCRIPTION
…eInterface". Some minor naming change in use statements in the MustacheEngine class. Otherwise Laratash won't run in Laravel ~5.5