### PR TITLE
Fixed Laravel 5.5 crash: Interface 'Illuminate\View\Engines\EngineInterface' not found

### DIFF
--- a/src/LaratashServiceProvider.php
+++ b/src/LaratashServiceProvider.php
@@ -46,7 +46,13 @@ class LaratashServiceProvider extends ServiceProvider
     private function registerMustacheEngine()
     {
         $this->app->bind('mustache.engine', function () {
-            return $this->app->make('Laratash\MustacheEngine');
+            // Support for Laravel 5.5+ contract view engine interface
+            $version = $this->app->version();
+            if (version_compare($version, '5.5', '>=')) {
+                return $this->app->make('Laratash\MustacheContractEngine');
+            }
+
+            return $this->app->make('Laratash\MustacheViewEngine');
         });
     }
 

--- a/src/MustacheContractEngine.php
+++ b/src/MustacheContractEngine.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laratash;
+
+use Illuminate\Contracts\View\Engine as ViewEngine;
+
+class MustacheContractEngine extends MustacheEngine implements ViewEngine
+{
+    //
+}

--- a/src/MustacheEngine.php
+++ b/src/MustacheEngine.php
@@ -6,7 +6,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Engines\EngineInterface;
 use Mustache_Engine;
 
-class MustacheEngine implements EngineInterface
+abstract class MustacheEngine
 {
     /** @var Filesystem */
     private $files;

--- a/src/MustacheViewEngine.php
+++ b/src/MustacheViewEngine.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laratash;
+
+use Illuminate\View\Engines\EngineInterface;
+
+class MustacheViewEngine extends MustacheEngine implements EngineInterface
+{
+    //
+}


### PR DESCRIPTION
Related to https://github.com/brightmachine/laratash/pull/9

Laravel now uses `Contracts\View\Engine` instead of the 5.5 deprecated `View\Engines\EngineInterface`.

This PR resolves the Laravel 5.5 compatibility issue experienced when trying to reference `EngineInterface` from the MustacheEngine class.

I've created two different `MustacheEngine` child classes which get constructed based on the current Laravel version.

Tested using sites that implement my fork using version:
- [ ] 5.0
- [x] 5.1
- [x] 5.2
- [ ] 5.3
- [ ] 5.4
- [x] 5.5
- [ ] dev-master

